### PR TITLE
Increased yard version

### DIFF
--- a/yard-sinatra.gemspec
+++ b/yard-sinatra.gemspec
@@ -2,11 +2,11 @@ SPEC = Gem::Specification.new do |s|
 
   # Get the facts.
   s.name             = "yard-sinatra"
-  s.version          = "0.5.1"
+  s.version          = "0.5.2"
   s.description      = "Displays Sinatra routes (including comments) in YARD output (part of BigBand)."
 
   # External dependencies
-  s.add_dependency "yard", "~> 0.6.0"
+  s.add_dependency "yard", "~> 0.7.0"
   s.add_development_dependency "rspec", ">= 1.3.0"
 
   # Those should be about the same in any BigBand extension.


### PR DESCRIPTION
I was having bundle trouble on a project using yard-sinatra with the newest version of yard, after bumping yard-sinatra's yard dependency to `~> 0.7.0` things are sailing smoothly.

Thought I would push this tiny fix upstream, tests pass and  yard-sinatra works great on my application now. Thanks for the wonderful plugin.
