### PR TITLE
support for sinatra namespaces

### DIFF
--- a/spec/example_app.rb
+++ b/spec/example_app.rb
@@ -36,6 +36,11 @@ class ExampleApp < Sinatra::Base
 
     # nested route
     get("/route") {"this is a nested route!"}
+
+		namespace "/double" do
+			# double nested route
+			get("/route") { }
+		end
   end
 
 end

--- a/spec/yard/sinatra_spec.rb
+++ b/spec/yard/sinatra_spec.rb
@@ -7,7 +7,7 @@ describe YARD::Sinatra do
   end
 
   it "reads sinatra routes" do
-    YARD::Sinatra.routes.size.should == 7
+    YARD::Sinatra.routes.size.should == 8
   end
 
   it "sets properties correctly" do
@@ -35,10 +35,12 @@ describe YARD::Sinatra do
 
   it "recognizes namespaced routes" do
     nested_routes = YARD::Sinatra.routes.find_all {|r| r.http_path[0..6] == "/nested" }
-    nested_routes.length.should == 2
+    nested_routes.length.should == 3
     nested_routes.each do |route|
       if route.http_path == "/nested"
         route.docstring.should == "root"
+      elsif route.http_path == "/nested/double/route"
+        route.docstring.should == "double nested route"
       elsif route.http_path == "/nested/route"
         route.docstring.should == "nested route"
       else


### PR DESCRIPTION
This add simple parsing/processing of namespaced routes for sinatra docs (as noted in issue #1).  It only manages the URL path of the nested routes and does nothing with any documentation placed on the namespace keyword (docs would still need to be placed on each route declaration).
