### PR TITLE
Implement @param tag handling

### DIFF
--- a/yard-sinatra.gemspec
+++ b/yard-sinatra.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
 
   # External dependencies
   s.add_dependency "yard", "~> 0.7"
+  s.add_dependency "mustermann", ">= 1.0"
   s.add_development_dependency "rspec", "~> 2.6"
 
   # Those should be about the same in any BigBand extension.


### PR DESCRIPTION
By parsing the route using Mustermann, we can find the named parameters; these can then be passed to the RouteObject so that YARD doesn't complain. It is important to set the docstring *after* the parameters are set, otherwise the unknown parameter warning will still occur once.

In RouteObject, we need to override the parameters attribute to prevent parameters from being shown in the signature of the route 'method', e.g. `#GET /:id(id)`, which looks strange.

Fixes #6.