### PR TITLE
Handles an error syntax and outputs it to the document

### DIFF
--- a/lib/yard/sinatra.rb
+++ b/lib/yard/sinatra.rb
@@ -117,6 +117,7 @@ module YARD
         handles method_call(:head)
         handles method_call(:not_found)
         handles method_call(:namespace)
+        handles method_call(:error)
 
         def http_verb
           statement.method_name(true).to_s.upcase
@@ -137,7 +138,7 @@ module YARD
       module Legacy
         class RouteHandler < Ruby::Legacy::Base
           include AbstractRouteHandler
-          handles /\A(get|post|put|patch|delete|head|not_found|namespace)[\s\(].*/m
+          handles /\A(get|post|put|patch|delete|head|not_found|namespace|error)[\s\(].*/m
 
           def http_verb
             statement.tokens.first.text.upcase


### PR DESCRIPTION
```rb
require 'sinatra'

# Internal Server Error
error 500 do
end
```

* bundle exec yard doc --plugin yard-sinatra app.rb

![evidence](https://user-images.githubusercontent.com/11570790/82868381-816be080-9f67-11ea-8443-bfbffeb58238.png)



